### PR TITLE
debian/control: Use DH 13, drop sb-provisioner depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,12 +2,12 @@ Source: pi-gen-micro
 Section: embedded
 Priority: optional
 Maintainer: Richard Oliver <richard.oliver@raspberrypi.com>
-Build-Depends: debhelper (>= 9)
+Build-Depends: debhelper (>= 13)
 Standards-Version: 3.9.5
 Homepage: https://www.raspberrypi.com/software
 
 Package: pi-gen-micro
 Architecture: arm64
 Pre-Depends: dpkg (>= 1.16.1), sed
-Depends: rpi-sb-provisioner
+Depends:
 Description: A tool to create cut-down Debian-based OS-images for Raspberry Pi Devices


### PR DESCRIPTION
rpi-sb-provisioner was required to ensure make-boot-image was available, however this isn't a safe dependency.

So let's drop that, and instead allow deployers to provide their own make-boot-image.

A following change will add a dependency on a new rpi-make-boot-image package.

Finally, use a more recent debhelper.