### PR TITLE
README: Add devscripts install instruction

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,8 +8,9 @@ Why? Because this means you get the latest hardware support and updates in line 
 == Installing
 
 === Build the package
-Use the standard Debian `devhelper` package:
+Use the standard Debian `devscripts` package:
 ```
+sudo apt install -y devscripts
 debuild -uc -us
 ```
 


### PR DESCRIPTION
The initial version of the README had an incorrect package name - devhelper instead of devscripts.

Correct that, and include a line to install this package as part of the build instructions.